### PR TITLE
Bugfix/repeated macros on same line

### DIFF
--- a/simplecpreprocessor.py
+++ b/simplecpreprocessor.py
@@ -234,15 +234,17 @@ class Preprocessor(object):
 
     def _recursive_transform(self, line, matches):
         original_line = line
+        new_matches = set()
 
         def transform_word(match):
             word = match.group(0)
             if word in matches:
                 return word
             else:
-                matches.add(word)
+                new_matches.add(word)
                 return self.defines.get(word, word)
         line = re.sub(r"\b\w+\b", transform_word, line)
+        matches.update(new_matches)
         if original_line == line:
             return line
         else:

--- a/test_simplecpreprocessor.py
+++ b/test_simplecpreprocessor.py
@@ -468,3 +468,10 @@ class TestSimpleCPreprocessor(ProfilerMixin, unittest.TestCase):
             self.assertEqual(os.fstat(f_obj.fileno()).st_ino,
                              file_info.st_ino)
             self.assertEqual(f_obj.name, __file__)
+
+    def test_repeated_macro(self):
+        f_obj = FakeFile("header.h", ['A A\n', ])
+        const = {"A": "value"}
+        ret = simplecpreprocessor.preprocess(f_obj,
+                                             platform_constants=const)
+        self.assertEqual(list(ret), ["value value\n"])


### PR DESCRIPTION
Turned out the replacement prevention was being too strict and not even expanding same token twice on the same line