### PR TITLE
Consistently use posixpath instead of os.path

### DIFF
--- a/simplecpreprocessor.py
+++ b/simplecpreprocessor.py
@@ -1,8 +1,8 @@
 import logging
-import os.path
 import platform
 import re
 import argparse
+import posixpath
 from pkg_resources import get_distribution, DistributionNotFound
 try:
     __version__ = get_distribution(__name__).version
@@ -36,7 +36,7 @@ class HeaderHandler(object):
 
     def _resolve(self, anchor_file):
         if anchor_file is not None:
-            yield os.path.dirname(anchor_file)
+            yield posixpath.dirname(anchor_file)
         for include_path in self.include_paths:
             yield include_path
 
@@ -48,8 +48,8 @@ class HeaderHandler(object):
             else:
                 return self._open(header_path)
         for include_path in self._resolve(anchor_file):
-            header_path = os.path.join(include_path, include_header)
-            f = self._open(os.path.normpath(header_path))
+            header_path = posixpath.join(include_path, include_header)
+            f = self._open(posixpath.normpath(header_path))
             if f:
                 self.resolved[include_header] = f.name
                 break
@@ -348,10 +348,6 @@ def preprocess(f_object, line_ending="\n", include_paths=(),
     preprocessor = Preprocessor(line_ending, include_paths, header_handler,
                                 platform_constants, ignore_headers)
     return preprocessor.preprocess(f_object)
-
-
-def split_paths(path):
-    return path.split(os.pathsep)
 
 
 parser = argparse.ArgumentParser()

--- a/test_simplecpreprocessor.py
+++ b/test_simplecpreprocessor.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import unittest
 import simplecpreprocessor
-import os.path
+import posixpath
 import os
 import cProfile
 from pstats import Stats
@@ -320,8 +320,8 @@ class TestSimpleCPreprocessor(ProfilerMixin, unittest.TestCase):
 
     def test_include_with_path_list(self):
         f_obj = FakeFile("header.h", ['#include <other.h>\n'])
-        handler = FakeHandler({os.path.join("subdirectory",
-                                            "other.h"): ["1\n"]})
+        handler = FakeHandler({posixpath.join("subdirectory",
+                                              "other.h"): ["1\n"]})
         include_paths = ["subdirectory"]
         ret = simplecpreprocessor.preprocess(f_obj,
                                              include_paths=include_paths,
@@ -343,11 +343,11 @@ class TestSimpleCPreprocessor(ProfilerMixin, unittest.TestCase):
         self.run_case(f_obj, expected_list)
 
     def test_include_with_path_list_with_subdirectory(self):
-        header_file = os.path.join("nested", "other.h")
+        header_file = posixpath.join("nested", "other.h")
         include_path = "somedir"
         f_obj = FakeFile("header.h", ['#include <%s>\n' % header_file])
-        handler = FakeHandler({os.path.join(include_path,
-                                            header_file): ["1\n"]})
+        handler = FakeHandler({posixpath.join(include_path,
+                                              header_file): ["1\n"]})
         include_paths = [include_path]
         ret = simplecpreprocessor.preprocess(f_obj,
                                              include_paths=include_paths,
@@ -355,7 +355,7 @@ class TestSimpleCPreprocessor(ProfilerMixin, unittest.TestCase):
         self.assertEqual(list(ret), ["1\n"])
 
     def test_include_missing_local_file(self):
-        other_header = os.path.join("somedirectory", "other.h")
+        other_header = posixpath.join("somedirectory", "other.h")
         f_obj = FakeFile("header.h", ['#include "%s"\n' % other_header])
         handler = FakeHandler({})
         with self.assertRaises(simplecpreprocessor.ParseError):
@@ -365,8 +365,8 @@ class TestSimpleCPreprocessor(ProfilerMixin, unittest.TestCase):
 
     def test_ignore_include_path(self):
         f_obj = FakeFile("header.h", ['#include <other.h>\n'])
-        handler = FakeHandler({os.path.join("subdirectory",
-                                            "other.h"): ["1\n"]})
+        handler = FakeHandler({posixpath.join("subdirectory",
+                                              "other.h"): ["1\n"]})
         paths = ["subdirectory"]
         ignored = ["other.h"]
         ret = simplecpreprocessor.preprocess(f_obj,


### PR DESCRIPTION
Using os.path led into sporadic results on Windows. Unit tests rely on a lookup dict and its keys weren't consistent if os.path.sep was backslash, hence use posixpath everywhere