### PR TITLE
Reduce amount of created objects (breaks backwards-compat)

### DIFF
--- a/simplecpreprocessor/tests.py
+++ b/simplecpreprocessor/tests.py
@@ -3,6 +3,7 @@ import unittest
 from simplecpreprocessor import preprocess
 from simplecpreprocessor.core import Preprocessor
 from simplecpreprocessor.exceptions import ParseError
+from simplecpreprocessor.tokens import Token
 from simplecpreprocessor.filesystem import FakeFile, FakeHandler
 import posixpath
 import os
@@ -477,7 +478,9 @@ class TestSimpleCPreprocessor(ProfilerMixin, unittest.TestCase):
     def test_platform_constants(self):
         f_obj = FakeFile("header.h", ['#ifdef ODDPLATFORM\n',
                                       'ODDPLATFORM\n', '#endif\n'])
-        const = {"ODDPLATFORM": "ODDPLATFORM"}
+        const = {
+            "ODDPLATFORM": [Token.from_string(None, "ODDPLATFORM")]
+        }
         ret = preprocess(f_obj, platform_constants=const)
         self.assertEqual("".join(ret), "ODDPLATFORM\n")
 
@@ -494,7 +497,8 @@ class TestSimpleCPreprocessor(ProfilerMixin, unittest.TestCase):
             self.assertEqual(f_obj.name, __file__)
 
     def test_repeated_macro(self):
-        f_obj = FakeFile("header.h", ['A A\n', ])
-        const = {"A": "value"}
-        ret = preprocess(f_obj, platform_constants=const)
+        f_obj = FakeFile("header.h", [
+            '#define A value\n'
+            'A A\n', ])
+        ret = preprocess(f_obj)
         self.assertEqual("".join(ret), "value value\n")

--- a/simplecpreprocessor/tokens.py
+++ b/simplecpreprocessor/tokens.py
@@ -44,19 +44,21 @@ class Token(object):
 class TokenExpander(object):
     def __init__(self, defines):
         self.defines = defines
+        self.seen = set()
 
-    def expand_tokens(self, tokens, seen=()):
+    def expand_tokens(self, tokens):
         for token in tokens:
-            if token.value not in self.defines or token.value in seen:
-                yield token.value
+            if token.value in self.seen:
+                yield token
             else:
-                new_seen = [token.value]
-                new_seen.extend(seen)
-                if len(new_seen) > 20:
-                    raise Exception("Stopping with stack %s" % new_seen)
-                tokens = self.defines[token.value]
-                for token in self.expand_tokens(tokens, new_seen):
+                resolved = self.defines.get(token.value, token)
+                if resolved is token:
                     yield token
+                else:
+                    self.seen.add(token.value)
+                    for resolved in self.expand_tokens(resolved):
+                        yield resolved
+                    self.seen.remove(token.value)
 
 
 class Tokenizer(object):


### PR DESCRIPTION
Noticed that in the normal case where platform constants were not
given, they still always went through reprocessing. This is now
optimized out.
Refactored token expander so that seen is now object-level scoped
thing to avoid continuously created more lists