### PR TITLE
Suppress IN and OUT on Windows

### DIFF
--- a/simplecpreprocessor/platform.py
+++ b/simplecpreprocessor/platform.py
@@ -11,7 +11,9 @@ def extract_platform_spec():
 
 def calculate_windows_constants(bitness):
     constants = {
-        "CALLBACK": "__stdcall"
+        "CALLBACK": "__stdcall",
+        "IN": "",
+        "OUT": "",
     }
     if bitness == "32bit":
         constants.update({

--- a/simplecpreprocessor/test_preprocessor.py
+++ b/simplecpreprocessor/test_preprocessor.py
@@ -692,14 +692,18 @@ def test_platform():
         assert calculate_platform_constants() == {
             "_WIN32": "1",
             "__SIZE_TYPE__": "size_t",
-            "CALLBACK": "__stdcall"
+            "CALLBACK": "__stdcall",
+            "IN": "",
+            "OUT": "",
         }
 
         mock_spec.return_value = "Windows", "64bit"
         assert calculate_platform_constants() == {
             "_WIN64": "1",
             "__SIZE_TYPE__": "size_t",
-            "CALLBACK": "__stdcall"
+            "CALLBACK": "__stdcall",
+            "IN": "",
+            "OUT": "",
         }
 
         with pytest.raises(UnsupportedPlatform) as excinfo:


### PR DESCRIPTION
These are quite commonly used for informative purposes. They don't
actually mean anything on code level. Remove them so they don't
confuse parser